### PR TITLE
Fix plugin meta-data in TTL

### DIFF
--- a/arpeggiator/source/arpeggiator.lv2/arpeggiator.ttl
+++ b/arpeggiator/source/arpeggiator.lv2/arpeggiator.ttl
@@ -16,18 +16,24 @@
     lv2:UtilityPlugin ,
     lv2:Plugin ;
     doap:name "Arpeggiator" ;
-    doap:license "GPLv2+" ;
+    doap:license <https://spdx.org/licenses/GPL-2.0-or-later> ;
     rdfs:comment """
-A beat syncable arpeggiator with velocity patterns and octave spread.  
+A beat syncable arpeggiator with velocity patterns and octave spread.
 """ ;
     lv2:minorVersion 1 ;
     lv2:microVersion 0 ;
     lv2:optionalFeature lv2:hardRTCapable ;
 
 doap:developer [
+    foaf:name "Bram Giesen" ;
+    foaf:homepage <https://bramgiesen.com> ;
+    foaf:mbox <mailto:bram@moddevices.com> ;
+    ];
+
+doap:maintainer [
     foaf:name "Bram Giesen";
-    foaf:homepage <>;
-    foaf:mbox <mailto:bram@moddevices.com>;
+    foaf:homepage <https://bramgiesen.com> ;
+    foaf:mbox <mailto:bram@moddevices.com> ;
     ];
 
 lv2:port

--- a/midi-pattern/source/midi-pattern.lv2/midi-pattern.ttl
+++ b/midi-pattern/source/midi-pattern.lv2/midi-pattern.ttl
@@ -16,24 +16,24 @@
     lv2:UtilityPlugin ,
     lv2:Plugin ;
     doap:name "MIDI Pattern" ;
-    doap:license "GPLv2+" ;
+    doap:license <https://spdx.org/licenses/GPL-2.0-or-later> ;
     rdfs:comment """
-A beat syncable midi-pattern plugin.  
+A beat syncable midi-pattern plugin.
 """ ;
     lv2:minorVersion 1 ;
     lv2:microVersion 0 ;
     lv2:optionalFeature lv2:hardRTCapable ;
 
 doap:developer [
-    foaf:name "Bram Giesen";
-    foaf:homepage <>;
-    foaf:mbox <mailto:bram@moddevices.com>;
+    foaf:name "Bram Giesen" ;
+    foaf:homepage <https://bramgiesen.com> ;
+    foaf:mbox <mailto:bram@moddevices.com> ;
     ];
 
 doap:maintainer [
     foaf:name "Bram Giesen";
-    foaf:homepage <http://bramgiesen.com>;
-    foaf:mbox <>;
+    foaf:homepage <https://bramgiesen.com> ;
+    foaf:mbox <mailto:bram@moddevices.com> ;
     ];
 
 lv2:port


### PR DESCRIPTION
- Add doap:maintainer to arpeggiator.ttl (lilv uses this as the "author").
- Set doap:license to an URI (required by LV2 spec).
- Make sure doap:homepage and doap:mbox are not empty.
- Use https schema for homepage URL.

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>