### PR TITLE
Merge 'control' into 'MIDI_in' port

### DIFF
--- a/arpeggiator/source/arpeggiator.c
+++ b/arpeggiator/source/arpeggiator.c
@@ -37,7 +37,6 @@ typedef enum {
     LATCH_MODE,
     DIVISIONS_PORT,
     SYNC_PORT,
-    CONTROL_PORT,   
     NOTELENGTH,
     OCTAVESPREAD,
     OCTAVEMODE,
@@ -74,7 +73,6 @@ typedef struct {
     float     divisions;
     double    samplerate;
     int       prevSync;
-    LV2_Atom_Sequence* control;
     // Variables to keep track of the tempo information sent by the host
     float     bpm; // Beats per minute (tempo)
     uint32_t  pos;
@@ -362,9 +360,6 @@ connect_port(LV2_Handle instance,
         case SYNC_PORT:
             self->sync = (float*)data;
             break;
-        case CONTROL_PORT:
-            self->control = (LV2_Atom_Sequence*)data;
-            break;
         case NOTELENGTH:
             self->note_length = (float*)data;
             break;
@@ -526,24 +521,9 @@ static void
 run(LV2_Handle instance, uint32_t n_samples)
 {
     Arpeggiator* self = (Arpeggiator*)instance;
-
     const ClockURIs* uris = &self->uris;
-    const LV2_Atom_Sequence* in = self->control;
-
-    for (const LV2_Atom_Event* ev = lv2_atom_sequence_begin(&in->body);
-            !lv2_atom_sequence_is_end(&in->body, in->atom.size, ev);
-            ev = lv2_atom_sequence_next(ev)) {
-        if (ev->body.type == uris->atom_Object ||
-                ev->body.type == uris->atom_Blank) {
-            const LV2_Atom_Object* obj = (const LV2_Atom_Object*)&ev->body;
-            if (obj->body.otype == uris->time_Position) {
-                update_position(self, obj);
-            }
-        }
-    }
 
     self->MIDI_out->atom.type = self->MIDI_in->atom.type;
-
     const uint32_t out_capacity = self->MIDI_out->atom.size;
 
     // Write an empty Sequence header to the output
@@ -553,7 +533,14 @@ run(LV2_Handle instance, uint32_t n_samples)
     LV2_ATOM_SEQUENCE_FOREACH(self->MIDI_in, ev)
     {
         size_t search_note;
-        if (ev->body.type == self->urid_midiEvent)
+        if (ev->body.type == uris->atom_Object ||
+                ev->body.type == uris->atom_Blank) {
+            const LV2_Atom_Object* obj = (const LV2_Atom_Object*)&ev->body;
+            if (obj->body.otype == uris->time_Position) {
+                update_position(self, obj);
+            }
+        }
+        else if (ev->body.type == self->urid_midiEvent)
         {
             const uint8_t* const msg = (const uint8_t*)(ev + 1);
 

--- a/arpeggiator/source/arpeggiator.lv2/arpeggiator.ttl
+++ b/arpeggiator/source/arpeggiator.lv2/arpeggiator.ttl
@@ -35,6 +35,7 @@ lv2:port
     a lv2:InputPort , atom:AtomPort ;
     atom:bufferType atom:Sequence ;
     atom:supports midi:MidiEvent ;
+    atom:supports time:Position ;
     lv2:index 0;
     lv2:symbol "MIDI_in" ;
     lv2:name "MIDI_in" ;
@@ -122,16 +123,8 @@ lv2:port
 ]
 ,
 [
-    a lv2:InputPort, atom:AtomPort ;
-    atom:bufferType atom:Sequence ;
-    atom:supports time:Position ;
-    lv2:index 7 ;
-    lv2:symbol "control" ;
-    lv2:name "Control" ;
-] ,
-[
     a lv2:InputPort, lv2:ControlPort ;
-    lv2:index 8;
+    lv2:index 7;
     lv2:symbol "noteLength" ;
     lv2:name "NoteLength" ;
     lv2:default 0.75 ;
@@ -141,7 +134,7 @@ lv2:port
 , 
 [
     a lv2:InputPort, lv2:ControlPort ;
-    lv2:index 9;
+    lv2:index 8;
     lv2:name "octaveSpread"  ;
     lv2:symbol "octaveSpread" ;
     lv2:default 1 ;
@@ -153,10 +146,10 @@ lv2:port
     lv2:scalePoint [ rdfs:label "3 Octaves" ; rdf:value 3 ] ;
     lv2:scalePoint [ rdfs:label "4 Octaves" ; rdf:value 4 ] ;
 ]
-, 
+,
 [
     a lv2:InputPort, lv2:ControlPort ;
-    lv2:index 10;
+    lv2:index 9;
     lv2:name "octaveMode"  ;
     lv2:symbol "octaveMode" ;
     lv2:default 0 ;
@@ -168,10 +161,10 @@ lv2:port
     lv2:scalePoint [ rdfs:label "Up-Down" ; rdf:value 2 ] ;
     lv2:scalePoint [ rdfs:label "Down-Up" ; rdf:value 3 ] ;
 ]
-, 
+,
 [
     a lv2:InputPort, lv2:ControlPort ;
-    lv2:index 11;
+    lv2:index 10;
     lv2:symbol "velocity" ;
     lv2:name "velocity" ;
     lv2:default 60 ;


### PR DESCRIPTION
As described in [this ticket](https://github.com/falkTX/Carla/issues/915), the arpeggiator plugin doesn't currently work in Carla, because of the additional `control` port, which receives `time:Position` atom events.

This PR merges this port into the `MIDI_in` port. The plugin then works in Carla and also still works in jalv and Ardour.

This PR is more of an FYI, to show that a workaround for using this plugin in Carla exists. Feel free to reject it.

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>